### PR TITLE
FCMサービスでFLAG_MUTABLEなど追加

### DIFF
--- a/src/android/com/adobe/phonegap/push/FCMService.java
+++ b/src/android/com/adobe/phonegap/push/FCMService.java
@@ -54,6 +54,9 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
   private static final String LOG_TAG = "Push_FCMService";
   private static HashMap<Integer, ArrayList<String>> messageMap = new HashMap<Integer, ArrayList<String>>();
 
+  private int FLAG_MUTABLE = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) ? 33554432 : 0;
+  private int FLAG_IMMUTABLE = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) ? PendingIntent.FLAG_IMMUTABLE : 0;
+
   public void setNotification(int notId, String message) {
     ArrayList<String> messageList = messageMap.get(notId);
     if (messageList == null) {
@@ -380,7 +383,7 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
     SecureRandom random = new SecureRandom();
     int requestCode = random.nextInt();
     PendingIntent contentIntent = PendingIntent.getActivity(this, requestCode, notificationIntent,
-        PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent.FLAG_UPDATE_CURRENT | FLAG_IMMUTABLE);
 
     Intent dismissedNotificationIntent = new Intent(this, PushDismissedHandler.class);
     dismissedNotificationIntent.putExtra(PUSH_BUNDLE, extras);
@@ -390,7 +393,7 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
 
     requestCode = random.nextInt();
     PendingIntent deleteIntent = PendingIntent.getBroadcast(this, requestCode, dismissedNotificationIntent,
-        PendingIntent.FLAG_CANCEL_CURRENT);
+        PendingIntent.FLAG_CANCEL_CURRENT | FLAG_IMMUTABLE);
 
     NotificationCompat.Builder mBuilder = null;
 
@@ -560,22 +563,22 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
             if (android.os.Build.VERSION.SDK_INT <= android.os.Build.VERSION_CODES.M) {
               Log.d(LOG_TAG, "push activity for notId " + notId);
               pIntent = PendingIntent.getActivity(this, uniquePendingIntentRequestCode, intent,
-                  PendingIntent.FLAG_ONE_SHOT);
+                  PendingIntent.FLAG_ONE_SHOT | FLAG_MUTABLE);
             } else {
               Log.d(LOG_TAG, "push receiver for notId " + notId);
               pIntent = PendingIntent.getBroadcast(this, uniquePendingIntentRequestCode, intent,
-                  PendingIntent.FLAG_ONE_SHOT);
+                  PendingIntent.FLAG_ONE_SHOT | FLAG_MUTABLE);
             }
           } else if (foreground) {
             intent = new Intent(this, PushHandlerActivity.class);
             updateIntent(intent, action.getString(CALLBACK), extras, foreground, notId);
             pIntent = PendingIntent.getActivity(this, uniquePendingIntentRequestCode, intent,
-                PendingIntent.FLAG_UPDATE_CURRENT);
+                PendingIntent.FLAG_UPDATE_CURRENT | FLAG_IMMUTABLE);
           } else {
             intent = new Intent(this, BackgroundActionButtonHandler.class);
             updateIntent(intent, action.getString(CALLBACK), extras, foreground, notId);
             pIntent = PendingIntent.getBroadcast(this, uniquePendingIntentRequestCode, intent,
-                PendingIntent.FLAG_UPDATE_CURRENT);
+                PendingIntent.FLAG_UPDATE_CURRENT | FLAG_IMMUTABLE);
           }
 
           NotificationCompat.Action.Builder actionBuilder = new NotificationCompat.Action.Builder(


### PR DESCRIPTION
## 変更内容

以下プラグインのAndroid 31対応を参考に、FCM Serviceの変更のみ反映。
https://github.com/havesource/cordova-plugin-push/commit/c3fb5b894afe17a05e21be135961f5831bafb1e0

## 確認したこと

- フォアグラウンドだとプッシュ通知が飛ぶようになった。
- バックグラウンドはこれまで同様、以下エラーが出る

```
E/AndroidRuntime: FATAL EXCEPTION: pool-4-thread-1
    Process: jp.co.ncdc.apppot.sample, PID: 29526
    java.lang.IllegalArgumentException: jp.co.ncdc.apppot.sample: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
    Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
        at android.app.PendingIntent.checkFlags(PendingIntent.java:401)
        at android.app.PendingIntent.getActivityAsUser(PendingIntent.java:484)
        at android.app.PendingIntent.getActivity(PendingIntent.java:470)
        at android.app.PendingIntent.getActivity(PendingIntent.java:434)
        at com.google.firebase.messaging.zza.zzt(Unknown Source:162)
        at com.google.firebase.messaging.zza.zzs(Unknown Source:199)
        at com.google.firebase.messaging.FirebaseMessagingService.handleIntent(Unknown Source:320)
        at com.google.firebase.iid.zzg.run(Unknown Source:29)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
        at java.lang.Thread.run(Thread.java:1012)
```

## 方針

- バックグラウンドまで対応しようと思うと、`FirebaseMessaging`を使う＆バージョンを上げる必要がある？
  - https://github.com/EddyVerbruggen/nativescript-plugin-firebase/issues/1876#issuecomment-1178736466
  - これをあげようと思うと、Android Studio、Javaなどのバージョン上げる必要ある？

- フォークされたプラグインでも、バックグラウンドでの通知が届かないというissueはある
  - https://github.com/havesource/cordova-plugin-push/issues/208